### PR TITLE
Added source to survey metadata

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/rhservice/service/EqPayloadBuilder.java
+++ b/src/main/java/uk/gov/ons/ssdc/rhservice/service/EqPayloadBuilder.java
@@ -64,10 +64,11 @@ public class EqPayloadBuilder {
   private Map<String, Object> getSurveyMetaData(UacUpdateDTO uacUpdateDTO) {
     Map<String, String> data = new HashMap<>();
     data.put("questionnaire_id", uacUpdateDTO.getQid());
+    data.put("source", "SRM");
 
     Map<String, Object> surveyMetaData = new HashMap<>();
     surveyMetaData.put("data", data);
-    surveyMetaData.put("receipting_keys", List.of("questionnaire_id"));
+    surveyMetaData.put("receipting_keys", List.of("questionnaire_id", "source"));
 
     return surveyMetaData;
   }

--- a/src/test/java/uk/gov/ons/ssdc/rhservice/service/EqPayloadBuilderTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/rhservice/service/EqPayloadBuilderTest.java
@@ -68,7 +68,9 @@ class EqPayloadBuilderTest {
         (Map<String, Object>) eqPayload.get("survey_metadata");
     Map<String, Object> actualData = (Map<String, Object>) actualSurveyMetaData.get("data");
     assertThat(actualData.get("questionnaire_id")).isEqualTo(uacUpdateDTO.getQid());
-    assertThat(actualSurveyMetaData.get("receipting_keys")).isEqualTo(List.of("questionnaire_id"));
+    assertThat(actualData.get("source")).isEqualTo("SRM");
+    assertThat(actualSurveyMetaData.get("receipting_keys"))
+        .isEqualTo(List.of("questionnaire_id", "source"));
   }
 
   private OffsetDateTime secondsStringToDateTime(long actualSeconds) {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For SDX to know it's a receipt from an adhoc survey, we're going to add a source to the survey metadata to the eqpayload so  it can be sent to SDX as well. 
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added `source` to receipting keys and survey_metadata data
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run `make build` and all tests should pass
- Run with the ATs and all tests should pass
- Enter in a UAC into RH-UI and get the token from the url. In ssdc-rm-dev-tools, use the decrypt token script and you should see the source in the payload
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/5MWC8p2n/)

