### PR TITLE
Remove account service logout URL

### DIFF
--- a/src/test/java/uk/gov/ons/ssdc/rhservice/endpoints/EqLaunchEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/rhservice/endpoints/EqLaunchEndpointTest.java
@@ -50,7 +50,6 @@ public class EqLaunchEndpointTest {
     String uacHash = "UAC_HASH";
     String languageCode = "LANGUAGE_CODE";
     String accountServiceUrl = "ACCOUNT_SERVICE_URL";
-    String accountServiceLogoutUrl = "ACCOUNT_SERVICE_LOGOUT_URL";
     UacUpdateDTO uacUpdateDTO = new UacUpdateDTO();
     uacUpdateDTO.setReceiptReceived(false);
     uacUpdateDTO.setActive(true);
@@ -88,7 +87,6 @@ public class EqLaunchEndpointTest {
     String uacHash = "UAC_HASH";
     String languageCode = "LANGUAGE_CODE";
     String accountServiceUrl = "ACCOUNT_SERVICE_URL";
-    String accountServiceLogoutUrl = "ACCOUNT_SERVICE_LOGOUT_URL";
     UacUpdateDTO uacUpdateDTO = new UacUpdateDTO();
     uacUpdateDTO.setReceiptReceived(true);
     uacUpdateDTO.setActive(false);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We send `account_service_url=rh-ui-url/en/start` to EQ. They then append `/en/start/` for the save and resume redirection. This means it ends up as `account_service_url=rh-ui-url/en/start/en/start`.
We also want to remove the `account_service_logout_url` from the token we send to EQ.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed `account_service_logout_url`
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build with the RH UI of the same name, run ATs.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/HuqjtCkR/532-bug-defect-eq-save-resume-endpoint-account-service-url-3
# Screenshots (if appropriate):
