### PR TITLE
Save all collex details to firestore

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/rhservice/model/dto/CollectionExerciseUpdateDTO.java
+++ b/src/main/java/uk/gov/ons/ssdc/rhservice/model/dto/CollectionExerciseUpdateDTO.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ssdc.rhservice.model.dto;
 
+import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,4 +12,13 @@ import lombok.NoArgsConstructor;
 public class CollectionExerciseUpdateDTO {
   private String collectionExerciseId;
   private List<CollectionInstrumentSelectionRule> collectionInstrumentRules;
+  private String name;
+  private String surveyId;
+  private String reference;
+
+  private Date startDate;
+
+  private Date endDate;
+
+  private Object metadata;
 }

--- a/src/test/java/uk/gov/ons/ssdc/rhservice/messaging/UacUpdateReceiverIT.java
+++ b/src/test/java/uk/gov/ons/ssdc/rhservice/messaging/UacUpdateReceiverIT.java
@@ -2,11 +2,8 @@ package uk.gov.ons.ssdc.rhservice.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.time.Instant;
+import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,7 +47,13 @@ class UacUpdateReceiverIT {
     CollectionExerciseUpdateDTO collectionExerciseUpdateDTO =
         new CollectionExerciseUpdateDTO(
             UUID.randomUUID().toString(),
-            List.of(new CollectionInstrumentSelectionRule("testUrl1", null)));
+            List.of(new CollectionInstrumentSelectionRule("testUrl1", null)),
+            "collex1",
+            UUID.randomUUID().toString(),
+            "clx",
+            Date.from(Instant.now()),
+            Date.from(Instant.now()),
+            List.of());
     collectionExerciseRepository.writeCollectionExerciseUpdate(collectionExerciseUpdateDTO);
 
     CaseUpdateDTO caseUpdateDTO =
@@ -96,7 +99,13 @@ class UacUpdateReceiverIT {
                     List.of(
                         new EqLaunchSettings("PARTICIPANT_ID", "participant_id", true),
                         new EqLaunchSettings("FIRST_NAME", "first_name", true))),
-                new CollectionInstrumentSelectionRule("differentUrl1", null)));
+                new CollectionInstrumentSelectionRule("differentUrl1", null)),
+            "collex1",
+            UUID.randomUUID().toString(),
+            "clx",
+            Date.from(Instant.now()),
+            Date.from(Instant.now()),
+            List.of());
     collectionExerciseRepository.writeCollectionExerciseUpdate(collectionExerciseUpdateDTO);
 
     CaseUpdateDTO caseUpdateDTO =
@@ -152,7 +161,13 @@ class UacUpdateReceiverIT {
                     List.of(
                         new EqLaunchSettings("PARTICIPANT_ID", "participant_id", true),
                         new EqLaunchSettings("FIRST_NAME", "first_name", true))),
-                new CollectionInstrumentSelectionRule("differentUrl1", null)));
+                new CollectionInstrumentSelectionRule("differentUrl1", null)),
+            "collex1",
+            UUID.randomUUID().toString(),
+            "clx",
+            Date.from(Instant.now()),
+            Date.from(Instant.now()),
+            List.of());
     collectionExerciseRepository.writeCollectionExerciseUpdate(collectionExerciseUpdateDTO);
 
     CaseUpdateDTO caseUpdateDTO =

--- a/src/test/java/uk/gov/ons/ssdc/rhservice/service/LaunchDataFieldSetterTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/rhservice/service/LaunchDataFieldSetterTest.java
@@ -5,10 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.time.Instant;
+import java.util.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,7 +52,13 @@ class LaunchDataFieldSetterTest {
     CollectionExerciseUpdateDTO collectionExerciseUpdateDTO =
         new CollectionExerciseUpdateDTO(
             UUID.randomUUID().toString(),
-            List.of(new CollectionInstrumentSelectionRule(TEST_URL, null)));
+            List.of(new CollectionInstrumentSelectionRule(TEST_URL, null)),
+            "collex1",
+            UUID.randomUUID().toString(),
+            "clx",
+            Date.from(Instant.now()),
+            Date.from(Instant.now()),
+            List.of());
     collectionExerciseRepository.writeCollectionExerciseUpdate(collectionExerciseUpdateDTO);
     when(collectionExerciseRepository.readCollectionExerciseUpdate(any()))
         .thenReturn(Optional.of(collectionExerciseUpdateDTO));
@@ -78,7 +82,13 @@ class LaunchDataFieldSetterTest {
             UUID.randomUUID().toString(),
             List.of(
                 new CollectionInstrumentSelectionRule(
-                    TEST_URL, List.of(new EqLaunchSettings("a", "b", true)))));
+                    TEST_URL, List.of(new EqLaunchSettings("a", "b", true)))),
+            "collex1",
+            UUID.randomUUID().toString(),
+            "clx",
+            Date.from(Instant.now()),
+            Date.from(Instant.now()),
+            List.of());
 
     collectionExerciseRepository.writeCollectionExerciseUpdate(collectionExerciseUpdateDTO);
     when(collectionExerciseRepository.readCollectionExerciseUpdate(any()))
@@ -103,7 +113,13 @@ class LaunchDataFieldSetterTest {
     CollectionExerciseUpdateDTO collectionExerciseUpdateDTO =
         new CollectionExerciseUpdateDTO(
             UUID.randomUUID().toString(),
-            List.of(new CollectionInstrumentSelectionRule(TEST_URL, null)));
+            List.of(new CollectionInstrumentSelectionRule(TEST_URL, null)),
+            "collex1",
+            UUID.randomUUID().toString(),
+            "clx",
+            Date.from(Instant.now()),
+            Date.from(Instant.now()),
+            List.of());
     collectionExerciseRepository.writeCollectionExerciseUpdate(collectionExerciseUpdateDTO);
     when(collectionExerciseRepository.readCollectionExerciseUpdate(any()))
         .thenReturn(Optional.of(collectionExerciseUpdateDTO));
@@ -121,7 +137,13 @@ class LaunchDataFieldSetterTest {
     CollectionExerciseUpdateDTO collectionExerciseUpdateDTO =
         new CollectionExerciseUpdateDTO(
             UUID.randomUUID().toString(),
-            List.of(new CollectionInstrumentSelectionRule(TEST_URL, new ArrayList<>())));
+            List.of(new CollectionInstrumentSelectionRule(TEST_URL, new ArrayList<>())),
+            "collex1",
+            UUID.randomUUID().toString(),
+            "clx",
+            Date.from(Instant.now()),
+            Date.from(Instant.now()),
+            List.of());
     collectionExerciseRepository.writeCollectionExerciseUpdate(collectionExerciseUpdateDTO);
     when(collectionExerciseRepository.readCollectionExerciseUpdate(any()))
         .thenReturn(Optional.of(collectionExerciseUpdateDTO));


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
At the moment, we don't store all of the collection exercise details in firestore so we're updating the rh service to get all the details we're already sent and store them as well

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Store all collex details in firestore
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the ATs and make sure all passes
- Create a collection exercise and make sure all the details are stored in firestore
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/PaePuWtJ/975-firestore-not-storing-whole-collection-exercise-object-5)
