### PR TITLE
SDCSRM-185 Fix Dependabot test failures in rh-service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
     </parent>
 
     <dependencyManagement>
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>spring-cloud-gcp-dependencies</artifactId>
-                <version>5.0.0</version>
+                <version>5.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.23</version>
+            <version>9.37.3</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
@@ -169,7 +169,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.16.0</version>
+                <version>3.21.2</version>
                 <configuration>
                     <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
                     <failurePriority>3</failurePriority>
@@ -250,7 +250,7 @@
             <plugin>
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.13</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/uk/gov/ons/ssdc/rhservice/crypto/EncodeJws.java
+++ b/src/main/java/uk/gov/ons/ssdc/rhservice/crypto/EncodeJws.java
@@ -8,7 +8,6 @@ import com.nimbusds.jose.JWSObject;
 import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jose.shaded.json.JSONObject;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ssdc.rhservice.model.dto.Key;
@@ -53,7 +52,6 @@ public class EncodeJws {
   }
 
   private Payload buildClaims(Map<String, Object> claims) {
-    JSONObject jsonObject = new JSONObject(claims);
-    return new Payload(jsonObject);
+    return new Payload(claims);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/rhservice/service/LaunchDataFieldSetter.java
+++ b/src/main/java/uk/gov/ons/ssdc/rhservice/service/LaunchDataFieldSetter.java
@@ -53,10 +53,12 @@ public class LaunchDataFieldSetter {
 
   private List<EqLaunchSettings> getEqLaunchSettingsFromCollectionExercise(
       String collectionExerciseId, String collectionInstrumentUrl) {
-    return collectionExerciseRepository.readCollectionExerciseUpdate(collectionExerciseId)
+    return collectionExerciseRepository
+        .readCollectionExerciseUpdate(collectionExerciseId)
         .orElseThrow(
             () -> new RuntimeException("Collection Exercise not found: " + collectionExerciseId))
-        .getCollectionInstrumentRules().stream()
+        .getCollectionInstrumentRules()
+        .stream()
         .filter(
             collexInstrumentRule ->
                 collexInstrumentRule.getCollectionInstrumentUrl().equals(collectionInstrumentUrl))


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There's a few dependabot PRs that need to be updated, especially after we've upgraded to spring boot 3
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Updated dependencies
- JSONObject from nimbus-jose-jwt was removed since they've moved to Gson instead. From the looks of it, the Payload doesn't need a JSONObject wrapper and we can just pass in the claims as a HashMap<String, Object>
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the branch against the ATs
- Get a launch token from rh-ui and run it against the decrypt_token.sh script in ssdc-rm-dev-tools. The output should match what you'd expect from before this change.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/RTUM4YdE/)
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-185)
