### PR TITLE
SDCSRM-385 Dependabot PRs for Security Only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "*"
-        update-types: [ "version-update:semver-major" ]
+        update-types: [ "version-update:semver-patch", "version-update:semver-minor" ]
     labels:
       - "patch"
       - "dependencies"


### PR DESCRIPTION
# Motivation and Context
We're getting overloaded with dependabot PRs so we needed a way to only get PRs for major updates

# What has changed
- Changed Config to only check for major version updates 
- Changed interval from Daily to Weekly 

# How to test?
Check it all looks ok

# Links
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-385)
