### PR TITLE
SDCSRM-388 Fix flaky unit test timing

### DIFF
--- a/src/test/java/uk/gov/ons/ssdc/rhservice/messaging/EqLaunchSenderTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/rhservice/messaging/EqLaunchSenderTest.java
@@ -1,14 +1,12 @@
 package uk.gov.ons.ssdc.rhservice.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static uk.gov.ons.ssdc.rhservice.messaging.EqLaunchSender.OUTBOUND_EVENT_SCHEMA_VERSION;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This particular unit test was intermittently failing in the build pipeline when the result wasn't within the arbitrary time window. I spent some time looking at it but couldn't see any good reason this test would run slower than any others, so I'm concluding for now that it's not a particular issue with this function or test performance, and is more likely down to performance hiccups in the build environment, and we simply don't test this timing in many (if any) other places to see the issue. For now, I am fixing it by checking the timing differently, simply checking the timestamp is within the time window of the test.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Fix flaky unit test timing

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the change. Nothing to test locally, the issue only seems to present in remote build environments.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-388