### PR TITLE
SDCSRM-542 Dependabot Security Only PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
     labels:
       - "patch"
       - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major" ]


### PR DESCRIPTION
# Motivation and Context
We want to limit the amount of dependabot PRs

# What has changed
Enabled grouping and only allowed security PRs

# How to test?
Check it looks ok

# Links
[SDCSRM-542](https://jira.ons.gov.uk/browse/SDCSRM-542)
