### PR TITLE
Changes required for corporate Macs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/*
 .java-version
 .DS_Store
 megalinter-reports/
+# Podman secrets
+podman-build-secret*

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER ?= $(shell if [ "$$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 install:
-	mvn clean install
+	CONTAINER_CLI=$(DOCKER) mvn clean install
 
 build: install docker-build
 
 build-no-test: install-no-test docker-build
 
 install-no-test:
-	mvn clean install -Dmaven.test.skip=true -Dexec.skip=true -Djacoco.skip=true
+	CONTAINER_CLI=$(DOCKER) mvn clean install -Dmaven.test.skip=true -Dexec.skip=true -Djacoco.skip=true
 
 format:
 	mvn fmt:format
@@ -18,19 +21,19 @@ check:
 	mvn fmt:check pmd:check
 
 test:
-	mvn clean verify jacoco:report
+	CONTAINER_CLI=$(DOCKER) mvn clean verify jacoco:report
 
 docker-build:
-	docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rh-service:latest
+	$(DOCKER) build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rh-service:latest
 
 megalint:  ## Run the mega-linter.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		oxsecurity/megalinter:v8
 
 megalint-fix:  ## Run the mega-linter and attempt to auto fix any issues.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		-e APPLY_FIXES=all \

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 	CONTAINER_CLI=$(DOCKER) mvn clean verify jacoco:report
 
 docker-build:
-	$(DOCKER) build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rh-service:latest
+	$(DOCKER) build . --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rh-service:latest
 
 megalint:  ## Run the mega-linter.
 	$(DOCKER) run --platform linux/amd64 --rm \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ The firestore allows it to be 'super fast' at reading data out for fast launchin
 
 ## Building
 
+Podman and Docker are both supported for building and running the application.
+By default the Makefile will use `docker` unless you are on an `arm64` architecture (e.g. M1/M2 Mac) in which case it will use `podman`.
+You can override this by setting the `DOCKER` environment variable to either `docker` or `podman`.
+For example, to force using `docker` on an M1/M2 Mac:
+```shell
+DOCKER=docker make <command>
+```
+
 To run all the tests, checks, formatting, and build the image:
 
 ```shell

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,25 @@
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
+        <container.cli>docker</container.cli>
     </properties>
+
+    <profiles>
+        <!-- Podman profile activated when env CONTAINER_CLI is set to "podman" -->
+        <!-- This is so podman will be used to run docker commands -->
+        <profile>
+            <id>podman</id>
+            <activation>
+                <property>
+                    <name>env.CONTAINER_CLI</name>
+                    <value>podman</value>
+                </property>
+            </activation>
+            <properties>
+                <container.cli>podman</container.cli>
+            </properties>
+        </profile>
+    </profiles>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -231,7 +249,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>docker</executable>
+                            <executable>${container.cli}</executable>
                             <commandlineArgs>compose -f src/test/resources/docker-compose.yml up -d</commandlineArgs>
                         </configuration>
                     </execution>
@@ -242,7 +260,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>docker</executable>
+                            <executable>${container.cli}</executable>
                             <commandlineArgs>compose -f src/test/resources/docker-compose.yml down -v</commandlineArgs>
                         </configuration>
                     </execution>


### PR DESCRIPTION
# Motivation and Context
In order to support the new corporate MacBooks we need to make changes to how images are built.

# What has changed
- Added ability to use podman or docker when building 
- Added info in README

# How to test?
Run and build it on both old and new macbooks (add `--no-cache` to the docker build to double check the build commands works fine on a blank slate)
Run both images in GCP and check it works as expected

# Links
[SDCSRM-1481](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1481)
